### PR TITLE
Add support for GHE and for path

### DIFF
--- a/gh.sh
+++ b/gh.sh
@@ -27,7 +27,7 @@ then
     exit 1
 fi
 
-giturl=${giturl/git\@github\.com\:/https://github.com/}
+giturl=$(echo $giturl | sed 's/git@\(.*\):/https:\/\/\1\//')
 giturl=${giturl%\.git}
 
 if [ -z "$2" ]
@@ -37,9 +37,11 @@ else
     branch="$2"
 fi
 
+path=$(git rev-parse --show-prefix)
+
 if [ ! -z "$branch" ]
 then
-    giturl="${giturl}/tree/${branch}"
+    giturl="${giturl}/tree/${branch}/${path}"
 fi
 
 open $giturl


### PR DESCRIPTION
1) The orginal script did not work with Github Enterprise repos. Using sed to capture the GHE domain when rewrting the remote, eg `git@git.example.com:user/repo` will be linked to `https://git.example.com/user/repo`.

2) Appending the path to the URL.
